### PR TITLE
Update CI to not use http's private CI images

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test against ponyc master
     runs-on: ubuntu-latest
     container:
-      image: ponylang/http-ci-x86-64-unknown-linux-builder:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/http-ci-x86-64-unknown-linux-builder:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release
     steps:
       - uses: actions/checkout@v1
       - name: Test


### PR DESCRIPTION
We don't reach into any other repo other than shared-docker to
get CI images for use. See https://github.com/ponylang/contributors/blob/master/ci/ci-image-organization.md
for more information.